### PR TITLE
Изменил адрес releases с eu на ru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 pack
 
 /tests/api/1c/http-client.private.env.json
+tests/api/1c/http-client.env.json

--- a/downloader/client.go
+++ b/downloader/client.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/khorevaa/logos"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
 	"sync"
+
+	"github.com/khorevaa/logos"
 )
 
-var releasesURL = "https://releases.1c.eu"
-var loginURL = "https://login.1c.eu"
+var releasesURL = "https://releases.1c.ru"
+var loginURL = "https://login.1c.ru"
 
 var log = logos.New("github.com/v8platform/oneget/downloader").Sugar()
 

--- a/downloader/oneDownloader_test.go
+++ b/downloader/oneDownloader_test.go
@@ -1,11 +1,12 @@
 package downloader
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_filterReleaseFiles(t *testing.T) {
@@ -186,7 +187,7 @@ func getAuth(t *testing.T) (string, string) {
 	pwd := os.Getenv("Password")
 
 	if login == "" || pwd == "" {
-		t.Skipf("Параметры авторизации на https://releases.1c.eu не заданы. тест пропускаем")
+		t.Skipf("Параметры авторизации на https://releases.1c.ru не заданы. тест пропускаем")
 	}
 	return login, pwd
 }

--- a/downloader/oneDownloader_test.go
+++ b/downloader/oneDownloader_test.go
@@ -41,7 +41,8 @@ func Test_filterReleaseFiles(t *testing.T) {
 				},
 			},
 			2,
-		}, {
+		},
+		{
 			"DevelopmentTools10 with Bellsoft JDK",
 			args{
 				list: []ReleaseFileInfo{
@@ -61,11 +62,12 @@ func Test_filterReleaseFiles(t *testing.T) {
 					},
 				},
 				filters: []FileFilter{
-					NewFileFilterMust("DevelopmentTools10", "deb"),
+					NewFileFilterMust(EDTProject, "deb"),
 				},
 			},
 			1,
-		}, {
+		},
+		{
 			"DevelopmentTools10 with Bellsoft JDK",
 			args{
 				list: []ReleaseFileInfo{
@@ -85,11 +87,12 @@ func Test_filterReleaseFiles(t *testing.T) {
 					},
 				},
 				filters: []FileFilter{
-					NewFileFilterMust("DevelopmentTools10", "deb"),
+					NewFileFilterMust(EDTProject, "deb"),
 				},
 			},
 			2,
-		}, {
+		},
+		{
 			"DevelopmentTools10 only Bellsoft JDK",
 			args{
 				list: []ReleaseFileInfo{
@@ -109,11 +112,12 @@ func Test_filterReleaseFiles(t *testing.T) {
 					},
 				},
 				filters: []FileFilter{
-					NewFileFilterMust("DevelopmentTools10", "deb.jdk.x64"),
+					NewFileFilterMust(EDTProject, "deb.jdk.x64"),
 				},
 			},
 			1,
-		}, {
+		},
+		{
 			"PosqtreSQL with 14.1-2.1C",
 			args{
 				list: []ReleaseFileInfo{
@@ -156,6 +160,8 @@ func TestOnegetDownloader_Platform_getFilesExist(t *testing.T) {
 	versions := []string{
 		"8.3.21.1302",
 		"8.3.21.1302",
+		"8.3.22.1672",
+		"8.3.21.1607",
 	}
 	for _, ver := range versions {
 		assert.True(t, releaseExist(t, platform, ver))
@@ -163,15 +169,15 @@ func TestOnegetDownloader_Platform_getFilesExist(t *testing.T) {
 
 }
 
+// На текущий момент тест не актуален, так как релизы все доступны
 func TestOnegetDownloader_Platform_getFilesNotExist(t *testing.T) {
 	platform := "Platform83"
 	// Список существующих платформ
 	versions := []string{
 		"8.3.22.1672",
-		"8.3.21.1607",
 	}
 	for _, ver := range versions {
-		assert.False(t, releaseExist(t, platform, ver))
+		assert.True(t, releaseExist(t, platform, ver))
 	}
 }
 

--- a/tests/api/1c/login.http
+++ b/tests/api/1c/login.http
@@ -1,14 +1,14 @@
 # Возвращает тикет аутентификации пользователя на портале поддержки.
 # Возвращенный тикет может быть проверен вызовом операции checkTicket()
 # сервиса https://login.1c.ru/api/public/ticket?wsdl или
-# https://login.1c.eu/api/public/ticket?wsdl.
+# https://login.1c.ru/api/public/ticket?wsdl.
 # Получение тикета выполняется в соответствии с настройками
 # библиотеки:
-# доменная зона серверов (1c.ru или 1c.eu);
+# доменная зона серверов (1c.ru или 1c.ru);
 
 ### Получение тикета 1С
 
-POST https://login.1c.eu/rest/public/ticket/get
+POST https://login.1c.ru/rest/public/ticket/get
 Content-Type: application/json
 
 {


### PR DESCRIPTION
Адрес предлагаю изменить в связи с тем, что с 19.01.2023 дистрибутивы в зоне eu недоступны по неизвестной причине, а сам ресурс releases.1c.eu работает с перебоями


Пруф того, что загрузка с ru не блокируется анти-ддос:
https://t.me/oscript_library/78815